### PR TITLE
Use post thumbnail and display feature post preview

### DIFF
--- a/css/large.css
+++ b/css/large.css
@@ -1,6 +1,6 @@
 html {
 	/* 20px left for blue top padding, using 60px for mobile site to make room for hamburger icon */
-	background-position: 0px 20px; 
+	background-position: 0px 20px;
 }
 
 .padding-top {
@@ -8,10 +8,10 @@ html {
 }
 
 .col.padding-bottom {
-	/* background scooted down 20px (60px mobile) so that blue top bar could precede hexagon design, 
+	/* background scooted down 20px (60px mobile) so that blue top bar could precede hexagon design,
 	need to move bottom blue bar down to cover the extra white background (note position: relative
 	defined in style.css */
-	top: 20px;		
+	top: 20px;
 }
 
 #menu-primary > li {
@@ -87,7 +87,7 @@ html {
 .row.news-section {
 	/* featured news story image will be perfectly left aligned with smaller news story
 	image below it */
-	text-align: left; 
+	text-align: left;
 	padding: 0px 40px;
 }
 

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 add_theme_support('menus');
+add_theme_support( 'post-thumbnails' );
 
 function register_theme_menus() {
   register_nav_menus(
@@ -9,21 +10,21 @@ function register_theme_menus() {
      )
    );
  }
- 
+
 //tell Wordpress to run this function upon initialization
 add_action('init', 'register_theme_menus');
 
-function wscs_theme_styles() { 
+function wscs_theme_styles() {
 	//wscs namespacing (to prevent conflicting names with future plugins etc)
 	//this function allows us to link to style sheets
 	//get_template_directory_uri() gets the path to the folder containing this file (functions.php)
 	//the period concatenates the above ^^ to css/materialize.css etc
 	wp_enqueue_style('materialize_css', get_template_directory_uri() . '/css/materialize.min.css');
-	wp_enqueue_style('main_css', get_template_directory_uri() . '/style.css');  
-	wp_enqueue_style('googlefont_css', 'https://fonts.googleapis.com/icon?family=Material+Icons'); 
+	wp_enqueue_style('main_css', get_template_directory_uri() . '/style.css');
+	wp_enqueue_style('googlefont_css', 'https://fonts.googleapis.com/icon?family=Material+Icons');
 	//array() and false are default values; needed to fill last parameter with media query
-	wp_enqueue_style('small_css', get_template_directory_uri() . '/css/small.css', array(), false, '(max-width:992px)');  
-	wp_enqueue_style('large_css', get_template_directory_uri() . '/css/large.css', array(), false, '(min-width:993px)');  
+	wp_enqueue_style('small_css', get_template_directory_uri() . '/css/small.css', array(), false, '(max-width:992px)');
+	wp_enqueue_style('large_css', get_template_directory_uri() . '/css/large.css', array(), false, '(min-width:993px)');
 }
 
 //needed to tell wordpress when to enqueue the styles
@@ -40,20 +41,20 @@ function wscs_theme_js() {
 
 add_action('wp_enqueue_scripts', 'wscs_theme_js');
 
-//Customizing menu output. See: http://www.kriesi.at/archives/improve-your-wordpress-navigation-menu-output 
+//Customizing menu output. See: http://www.kriesi.at/archives/improve-your-wordpress-navigation-menu-output
 //Also see: https://developer.wordpress.org/reference/classes/walker_category/ (very helpful)
 //TODO: right now, we're assuming every parent has a child submenu (in Desktop, all parents have the triangle to their left
 //and in responsive every parent is structured assuming it has children)
 class wscs_materializecss_large_walker extends Walker_Nav_Menu
 {
-	// modified to add id corresponding to parent (child-of-CURRENTID) in every child ul, 
-	// in every parent set data-activates to corresponding child submenu id 
+	// modified to add id corresponding to parent (child-of-CURRENTID) in every child ul,
+	// in every parent set data-activates to corresponding child submenu id
 
 	//we use a shared variable to keep track of who the parent was
 	private $wscsCurItem;
 
   //Note: The start level refers to the start of a sub-level. Meaning that the output does not effect the initial wrapping around the whole navigation, but only the list of childerns children (https://developer.wordpress.org/reference/classes/walker/start_lvl/)
-	function start_lvl(&$output, $depth) 
+	function start_lvl(&$output, $depth)
 	{
 	   $indent = str_repeat("\t", $depth);
 
@@ -111,14 +112,14 @@ class wscs_materializecss_large_walker extends Walker_Nav_Menu
 class wscs_materializecss_small_walker extends Walker_Nav_Menu
 {
   //Note: The start level refers to the start of a sub-level. Meaning that the output does not effect the initial wrapping around the whole navigation, but only the list of childerns children (https://developer.wordpress.org/reference/classes/walker/start_lvl/)
-  function start_lvl(&$output, $depth) 
+  function start_lvl(&$output, $depth)
   {
      $indent = str_repeat("\t", $depth);
      //collapsible body tag added
      $output .= "\n" . $indent . '<div class="collapsible-body"><ul>';
   }
 
-  function end_lvl( &$output, $depth = 0, $args = array() ) 
+  function end_lvl( &$output, $depth = 0, $args = array() )
   {
     $indent = str_repeat("\t", $depth);
     // These close the tags that were added
@@ -170,12 +171,12 @@ class wscs_materializecss_small_walker extends Walker_Nav_Menu
 }
 
 function envira_gallery_image_titles( $output, $id, $item, $data, $i ) {
-  
+
   // IDs of galleries to display titles on
   $galleriesToShowTitles = array(
     79
   );
-  
+
   // Check if we need to display titles on this gallery
   if ( !in_array( $data['id'], $galleriesToShowTitles ) ) {
     return $output;
@@ -186,8 +187,15 @@ function envira_gallery_image_titles( $output, $id, $item, $data, $i ) {
   }
 
   return $output;
-  
+
 }
 add_action( 'envira_gallery_output_after_link', 'envira_gallery_image_titles', 10, 5 );?>
+
+?>
+
+function modify_read_more_link() {
+    return '<a class="button" href="' . get_permalink() . '">Read Full Story</a>';
+}
+add_filter( 'the_content_more_link', 'modify_read_more_link' );
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -189,9 +189,7 @@ function envira_gallery_image_titles( $output, $id, $item, $data, $i ) {
   return $output;
 
 }
-add_action( 'envira_gallery_output_after_link', 'envira_gallery_image_titles', 10, 5 );?>
-
-?>
+add_action( 'envira_gallery_output_after_link', 'envira_gallery_image_titles', 10, 5 );
 
 function modify_read_more_link() {
     return '<a class="button" href="' . get_permalink() . '">Read Full Story</a>';

--- a/index.php
+++ b/index.php
@@ -61,44 +61,66 @@
 
 	<div class="col s12 section-divider"></div>
 
-	<?php $first = true; ?>
+  <?php
+    $postctr = 0;
+    global $more;
+  ?>
 	<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
-		<?php if ( $first ): ?>
+		<?php if ( $postctr === 0 ): ?>
 			<div class="row news-section">
 		    	<div class="label"> <h2>News</h2> </div>
 		      	<div class="col s12 post">
 			        <!-- TODO: deal with how much content is outputted here, and making sure it's centered; problem is need vertical-align: top to keep news div in line with image div -->
-			        <div class="image feature"></div>
+			        <!--div class="image feature"></div-->
+              <?php
+                if ( has_post_thumbnail() ) {
+                  the_post_thumbnail(
+                    'post-thumbnail', ['class' => 'image feature', 'title' => 'Feature Post Thumbnail']);
+                }
+                else {
+                    echo '<img class="image feature" src="' . get_bloginfo( 'stylesheet_directory' )
+                        . '/img/feature.jpeg" />';
+                }
+              ?>
 		        	<div class="news feature">
                 <div class="content feature">
                   <h3><?php the_title() ?></h3>
                   <h4>by women@scs</h4>
-                  <p class="description"><?php the_content() ?></p>
+                  <p class="description">
                     <?php
-                      echo sprintf(
-                        '<a class="button" href="%s" rel="bookmark">
-                           Read Full Story
-                         </a>', esc_url(get_permalink())); ?>
+                      $more = 0;
+                      the_content();
+                    ?>
+                  </p>
 		         		</div>
 		        	</div>
 		      	</div>
 		    </div>
 		    <!-- TODO: hacky way of starting next row -->
 		    <div class="row news-section">
-			<?php $first = false; ?>
-	    <?php else: ?>
+			<?php $postctr = $postctr + 1; ?>
+	    <?php elseif ($postctr < 4): ?>
 		    <div class="col s12 l4 post">
           <?php
               echo sprintf(
-                '<a class="post-link" href="%s">
-                  <div class="image"></div>
-                  <div class="news">
+                '<a class="post-link" href="%s">', esc_url(get_permalink()));
+              if ( has_post_thumbnail() ) {
+                  the_post_thumbnail();
+              }
+              else {
+                  echo '<img class="image" src="' . get_bloginfo( 'stylesheet_directory' )
+                      . '/img/feature.jpeg" />';
+              }
+              echo sprintf(
+                '<div class="news">
                     <div class="content">
                         <h5>%s</h5>
                         <h6>by women@scs</h6>
                       </div>
                   </div>
-                </a>', esc_url(get_permalink()), the_title('','',false)); ?>
+                  </a>', the_title('','',false));
+              $postctr = $postctr + 1;
+           ?>
 		    </div>
 	    <?php endif; ?>
 	<?php endwhile; else : ?>

--- a/style.css
+++ b/style.css
@@ -126,4 +126,3 @@ iframe {
 	left: 20px;
 	height: 40px;
 }
->>>>>>> Use post thumbnail and display feature post preview

--- a/style.css
+++ b/style.css
@@ -57,16 +57,6 @@ p {
 	color: #46524e;
 }
 
-h3.title {
-	padding-top: 30px;
-	text-align: center;
-	display: block;
-	letter-spacing: 1px;
-	font-size: 3.5rem;
-	margin: 7px;
-	font-weight: 600;
-}
-
 iframe {
 	max-width: 100%;
 }
@@ -105,11 +95,6 @@ iframe {
   	width: 100%;
 }
 
-.image {
-	background-image: url(img/feature.jpeg);
-	background-size: cover;
-}
-
 .button {
 	background-color: #00294b;
 	font-size: .9rem;
@@ -118,7 +103,9 @@ iframe {
 	color: #fff;
 	border-radius: 15px;
 	line-height: 3;
-  padding: 16px 24px;
+  padding: 6px 24px;
+  margin-top: 24px;
+  display: inline-block
 }
 
 .button:hover {
@@ -139,3 +126,4 @@ iframe {
 	left: 20px;
 	height: 40px;
 }
+>>>>>>> Use post thumbnail and display feature post preview


### PR DESCRIPTION
I changed the theme to allow adding thumbnail images to posts for displaying on
the front page. Now, for posts on the front page with thumbnail images, we use
the appropriate thumbnail image. For posts without thumbnail images, we use the
same default image as before. We might want to change the default image in the
future before launching.

I also changed the main featured post to only display a portion of the content,
not the whole post. We should only show the part of the post before the `more`
tag, or things will start looking weird.